### PR TITLE
Performance Improvements for Advancements & Hidden Things

### DIFF
--- a/src/main/java/com/cmdpro/databank/DatabankUtils.java
+++ b/src/main/java/com/cmdpro/databank/DatabankUtils.java
@@ -17,6 +17,7 @@ import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.PlayerList;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -24,12 +25,50 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class DatabankUtils {
+
+    private static final Set<UUID> scheduledUpdateHidden = new HashSet<>();
+    private static final Map<UUID, List<ResourceLocation>> playerUnlockedCache = new HashMap<>();
+    private static final Map<UUID, Map<ResourceLocation, Boolean>> scheduledUpdateAdvancement = new HashMap<>();
+
+    public static void scheduleUpdateHidden(Player player) {
+        scheduledUpdateHidden.add(player.getUUID());
+    }
+
+    public static void sendScheduledUpdates(MinecraftServer server) {
+        PlayerList players = server.getPlayerList();
+        if (!scheduledUpdateHidden.isEmpty()) {
+            for(UUID id : scheduledUpdateHidden) {
+                ServerPlayer player = players.getPlayer(id);
+                if (player != null && ! player.hasDisconnected())
+                    updateHidden(player, true, false);
+            }
+            scheduledUpdateHidden.clear();
+        }
+
+        if (!scheduledUpdateAdvancement.isEmpty()) {
+            for(Map.Entry<UUID, Map<ResourceLocation, Boolean>> entry : scheduledUpdateAdvancement.entrySet()) {
+                ServerPlayer player = players.getPlayer(entry.getKey());
+                if (player != null && ! player.hasDisconnected()) {
+                    for(Map.Entry<ResourceLocation, Boolean> e : entry.getValue().entrySet()) {
+                        ModMessages.sendToPlayer(e.getValue()
+                                ? new UnlockAdvancementS2CPacket(e.getKey())
+                                : new LockAdvancementS2CPacket(e.getKey()),
+                                player
+                        );
+                    }
+                }
+            }
+            scheduledUpdateAdvancement.clear();
+        }
+    }
+
+    public static void uncachePlayerHidden(Player player) {
+        playerUnlockedCache.remove(player.getUUID());
+    }
+
     public static BlockState changeBlockType(BlockState originalState, Block newType) {
         BlockState state = newType.defaultBlockState();
         for (Property<?> i : originalState.getProperties()) {
@@ -47,25 +86,58 @@ public class DatabankUtils {
         return new ItemStack(Holder.direct(newType), originalStack.getCount(), originalStack.getComponentsPatch());
     }
     public static void updateHidden(Player player) {
-        updateHidden(player, true);
+        updateHidden(player, true, true);
     }
     public static void updateHidden(Player player, boolean updateListeners) {
+        updateHidden(player, updateListeners, true);
+    }
+    public static void updateHidden(Player player, boolean updateListeners, boolean removeScheduled) {
+        UUID id = player.getUUID();
+        // If not otherwise told not to, remove this player from the scheduled updates
+        // list because they'll be up-to-date after this gets sent.
+        if (removeScheduled)
+            scheduledUpdateHidden.remove(id);
+
+        // Compute the player's list of unlocks.
         List<ResourceLocation> unlocked = new ArrayList<>();
-        for (Map.Entry<ResourceLocation, Hidden> i : new HashMap<>(HiddenManager.hidden).entrySet()) {
+        for (Map.Entry<ResourceLocation, Hidden> i : HiddenManager.hidden.entrySet()) {
             if (i.getValue().condition.isUnlocked(player)) {
                 unlocked.add(i.getKey());
             }
         }
+
+        // If we have a cached state for this player, and it matches the new state, then we don't actually
+        // need to send an update to the client.
+        List<ResourceLocation> oldUnlocked = playerUnlockedCache.get(id);
+        if (oldUnlocked != null && oldUnlocked.size() == unlocked.size() && unlocked.containsAll(oldUnlocked))
+            return;
+
+        // Cache the newly sent state and send it to the player.
+        playerUnlockedCache.put(id, unlocked);
         ModMessages.sendToPlayer(new UnlockedHiddenSyncS2CPacket(unlocked, updateListeners), (ServerPlayer)player);
     }
     public static void unlockHiddenBlock(Player player, ResourceLocation hiddenBlock) {
+        // If there's a cached set of hidden unlocks already sent to the player, we might be
+        // able to avoid this.
+        List<ResourceLocation> oldUnlocked = playerUnlockedCache.get(player.getUUID());
+        if (oldUnlocked != null) {
+            // If we have a match, we don't need to do anything.
+            if (oldUnlocked.contains(hiddenBlock))
+                return;
+
+            // We don't have a match, so go ahead and add it to the cached list.
+            oldUnlocked.add(hiddenBlock);
+        }
+
         ModMessages.sendToPlayer(new UnlockHiddenSyncS2CPacket(hiddenBlock), (ServerPlayer)player);
     }
     public static void sendUnlockAdvancement(Player player, ResourceLocation advancement) {
-        ModMessages.sendToPlayer(new UnlockAdvancementS2CPacket(advancement), (ServerPlayer)player);
+        scheduledUpdateAdvancement.computeIfAbsent(player.getUUID(), k -> new HashMap<>()).put(advancement, true);
+        //ModMessages.sendToPlayer(new UnlockAdvancementS2CPacket(advancement), (ServerPlayer)player);
     }
     public static void sendLockAdvancement(Player player, ResourceLocation advancement) {
-        ModMessages.sendToPlayer(new LockAdvancementS2CPacket(advancement), (ServerPlayer)player);
+        scheduledUpdateAdvancement.computeIfAbsent(player.getUUID(), k -> new HashMap<>()).put(advancement, false);
+        //ModMessages.sendToPlayer(new LockAdvancementS2CPacket(advancement), (ServerPlayer)player);
     }
     public static float kelvinToCelcius(float kelvin) {
         return kelvin+273.15f;


### PR DESCRIPTION
Hey there! I've been playing on a server with some friends recently with a custom pack, and one user in particular has been having some horrible performance issues when around my base. I was able to track it down to an interaction between a few datapacks, notably Incendium, which add a lot of technical advancements for reacting to events in conjunction with Databank and Pastel.

In some cases, one of Incendium's technical advancements can be granted and revoked within a single server tick. This happening is enough to cause Databank to send an updated list of unlocked hidden things to affected clients, potentially multiple times in a single tick. Not good.

Then, on the client side of things, there was some unoptimized code in the handler for `UnlockedHiddenSyncS2CPacket` that made things worse, especially when you factor in how many changes could be sent by something like Incendium's advancements. Worse, the unlocked things aren't even changing when this happens.

To address these issues I've made a few changes. First, regarding server-side changes:

1. `UnlockedHiddenSyncS2CPacket`, `LockAdvancementS2CPacket`, and `UnlockAdvancementS2CPacket` are now batched and sent to each relevant player once in the post-tick phase.
2. In the case of `UnlockedHiddenSync`, it may still be sent earlier by direct calls to `DatabankUtils.updateHidden()`, and doing so will cancel any scheduled post-tick packet from being sent.
3. Each player's most recent unlocked hidden state is cached in the server, and the packet is not sent if the list has not changed since it was last sent. This cached state is cleared whenever the player disconnects, and when datapacks change.
4. In the case of the advancement packets, those are tracked per advancement and the player only receives the most recent state. If an advancement is marked granted and then marked revoked within a single tick, for example, then the player only receives a `LockAdvancementS2CPacket` for that advancement.

Then, in the client:

1. In the `handleClient` method of `UnlockedHiddenSyncS2CPacket`, the logic for computing the relevant lists has been rewritten to minimize necessary iterations and allocations. Admittedly the code is more verbose now, but in my performance testing it's been running much faster even without the server changes in place.

---

Even just running this client side allowed my friend, who previously only got around 2-5 fps in my base due to Databank, to reach 40+ fps in the same scenario.

I still have a little more testing I want to do, but I wanted to get this posted so you can see it, see what you think, and provide any feedback.